### PR TITLE
Fix nifm for 20.0.0+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFILES	:=	sysmod overlay
 TARGETS		:= $(foreach dir,$(MAKEFILES),$(CURDIR)/$(dir))
 
 # the below was taken from atmosphere + switch-examples makefile
-export VERSION := 1.5.5
+export VERSION := 1.5.6
 
 ifneq ($(strip $(shell git symbolic-ref --short HEAD 2>/dev/null)),)
 export GIT_BRANCH := $(shell git symbolic-ref --short HEAD)

--- a/overlay/src/main.cpp
+++ b/overlay/src/main.cpp
@@ -116,6 +116,7 @@ public:
 
         list->addItem(new tsl::elm::CategoryHeader("NIFM - 010000000000000F"));
         list->addItem(config_ctest.create_list_item("ctest"));
+        list->addItem(config_ctest2.create_list_item("ctest2"));
 
         list->addItem(new tsl::elm::CategoryHeader("NIM - 0100000000000025"));
         list->addItem(config_nim.create_list_item("nim"));
@@ -140,6 +141,7 @@ public:
     ConfigEntry config_es2{"es", "es2", true};
     ConfigEntry config_es3{"es", "es3", true};
     ConfigEntry config_ctest{"nifm", "ctest", true};
+    ConfigEntry config_ctest2{"nifm", "ctest2", true};
     ConfigEntry config_nim{"nim", "nim", true};
     ConfigEntry config_ssl1{"ssl", "disablecaverification1", false};
     ConfigEntry config_ssl2{"ssl", "disablecaverification2", false};

--- a/sysmod/src/main.cpp
+++ b/sysmod/src/main.cpp
@@ -200,6 +200,11 @@ constexpr auto ctest_cond(u32 inst) -> bool {
     return std::byteswap(0xF50301AA) == inst; // mov x21, x1
 }
 
+constexpr auto b_cond(u32 inst) -> bool {
+    const auto type = inst >> 24;
+    return type == 0x14 || type == 0x17;
+}
+
 // to view patches, use https://armconverter.com/?lock=arm64
 constexpr PatchData ret0_patch_data{ "0xE0031F2A" };
 constexpr PatchData ret1_patch_data{ "0x10000014" };
@@ -292,7 +297,8 @@ constinit Patterns es_patterns[] = {
 };
 
 constinit Patterns nifm_patterns[] = {
-    { "ctest", "....................F40300AA....F30314AAE00314AA9F0201397F8E04F8", 16, -16, ctest_cond, ctest_patch, ctest_applied, true, FW_VER_ANY },
+    { "ctest", "....................F40300AA....F30314AAE00314AA9F0201397F8E04F8", 16, -16, ctest_cond, ctest_patch, ctest_applied, true, FW_VER_ANY, MAKEHOSVERSION(18,1,0) }, // 1.0.0 - 18.1.0
+    { "ctest2", "14...........91...........97...............14", 37, 4, b_cond, ctest_patch, ctest_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY }, //19.0.0 - 20.0.1+
 };
 
 constinit Patterns nim_patterns[] = {


### PR DESCRIPTION
needs verification that the b_test cond hits the correct address (testing the raw file it uses byte 40:41 for the 0x14 register.


I do not have a physical console anymore, so i wont be testing.