### PR TITLE
fix fs, nim for 21.0.0, replace loader patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFILES	:=	sysmod overlay
 TARGETS		:= $(foreach dir,$(MAKEFILES),$(CURDIR)/$(dir))
 
 # the below was taken from atmosphere + switch-examples makefile
-export VERSION := 1.5.6
+export VERSION := 1.5.7
 
 ifneq ($(strip $(shell git symbolic-ref --short HEAD 2>/dev/null)),)
 export GIT_BRANCH := $(shell git symbolic-ref --short HEAD)

--- a/overlay/src/main.cpp
+++ b/overlay/src/main.cpp
@@ -102,6 +102,7 @@ public:
         list->addItem(config_noacidsigchk1.create_list_item("noacidsigchk1"));
         list->addItem(config_noacidsigchk2.create_list_item("noacidsigchk2"));
         list->addItem(config_noncasigchk_old.create_list_item("noncasigchk_old"));
+        list->addItem(config_noncasigchk_old2.create_list_item("noncasigchk_old2"));
         list->addItem(config_noncasigchk_new.create_list_item("noncasigchk_new"));
         list->addItem(config_nocntchk.create_list_item("nocntchk"));
         list->addItem(config_nocntchk2.create_list_item("nocntchk2"));
@@ -119,7 +120,9 @@ public:
         list->addItem(config_ctest2.create_list_item("ctest2"));
 
         list->addItem(new tsl::elm::CategoryHeader("NIM - 0100000000000025"));
-        list->addItem(config_nim.create_list_item("nim"));
+        list->addItem(config_nim.create_list_item("nim_old"));
+        list->addItem(config_nim.create_list_item("nim_new"));
+
 
         list->addItem(new tsl::elm::CategoryHeader("Disable CA Verification - apply all"));
         list->addItem(config_ssl1.create_list_item("disablecaverification1"));
@@ -133,6 +136,7 @@ public:
     ConfigEntry config_noacidsigchk1{"fs", "noacidsigchk1", true};
     ConfigEntry config_noacidsigchk2{"fs", "noacidsigchk2", true};
     ConfigEntry config_noncasigchk_old{"fs", "noncasigchk_old", true};
+    ConfigEntry config_noncasigchk_old2{"fs", "noncasigchk_old2", true};
     ConfigEntry config_noncasigchk_new{"fs", "noncasigchk_new", true};
     ConfigEntry config_nocntchk{"fs", "nocntchk", true};
     ConfigEntry config_nocntchk2{"fs", "nocntchk2", true};
@@ -142,7 +146,8 @@ public:
     ConfigEntry config_es3{"es", "es3", true};
     ConfigEntry config_ctest{"nifm", "ctest", true};
     ConfigEntry config_ctest2{"nifm", "ctest2", true};
-    ConfigEntry config_nim{"nim", "nim", true};
+    ConfigEntry config_nim{"nim_old", "nim_old", true};
+    ConfigEntry config_nim{"nim_new", "nim_new", true};
     ConfigEntry config_ssl1{"ssl", "disablecaverification1", false};
     ConfigEntry config_ssl2{"ssl", "disablecaverification2", false};
     ConfigEntry config_ssl3{"ssl", "disablecaverification3", false};

--- a/sysmod/src/main.cpp
+++ b/sysmod/src/main.cpp
@@ -266,7 +266,8 @@ constinit Patterns fs_patterns[] = {
     { "noacidsigchk1", "0xC8FE4739", -24, 0, bl_cond, ret0_patch, ret0_applied, true, FW_VER_ANY, MAKEHOSVERSION(9,2,0) },
     { "noacidsigchk2", "0x0210911F000072", -5, 0, bl_cond, ret0_patch, ret0_applied, true, FW_VER_ANY, MAKEHOSVERSION(9,2,0) },
     { "noncasigchk_old", "0x0036.......71..0054..4839", -2, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(10,0,0), MAKEHOSVERSION(16,1,0) },
-    { "noncasigchk_new", "0x.94..0036.258052", 2, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(17,0,0), FW_VER_ANY }, // 17.0.0 - 19.0.0+
+    { "noncasigchk_old2", "0x.94..0036.258052", 2, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(17,0,0), MAKEHOSVERSION(20,5,0) }, // 17.0.0 - 20.5.0
+    { "noncasigchk_new", "0x.94..0036.........258052", 2, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(21,0,0), FW_VER_ANY }, // 21.0.0+
     { "nocntchk", "0x40f9...9408.0012.050071", 2, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(10,0,0), MAKEHOSVERSION(18,1,0) },
     { "nocntchk2", "0x40f9...94..40b9..0012", 2, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
 };
@@ -287,7 +288,8 @@ constinit Patterns nifm_patterns[] = {
 };
 
 constinit Patterns nim_patterns[] = {
-    { "nim", "0x.0F00351F2003D5", 8, 0, adr_cond, mov2_patch, mov2_applied, true, MAKEHOSVERSION(17,0,0), FW_VER_ANY },
+    { "nim_old", "0x.0F00351F2003D5", 8, 0, adr_cond, mov2_patch, mov2_applied, true, MAKEHOSVERSION(17,0,0), MAKEHOSVERSION(20,5,0) },
+    { "nim_new", "0x.0700351F2003D5", 8, 0, adr_cond, mov2_patch, mov2_applied, true, MAKEHOSVERSION(21,0,0), FW_VER_ANY },
 };
 
 constinit Patterns ssl_patterns[] = {


### PR DESCRIPTION
im assuming the syntax is correct

byte desired to be patched: (8), compared against cmp instruction 2 bytes before the byte desired to be patched (-2)

this PR might not be needed, but im submitting it regardless.

the new patch just changes `cmp w0, w1` into `cmp w0, w0`
