### PR TITLE
actually verify ctest for newer firmware

### DIFF
--- a/overlay/src/main.cpp
+++ b/overlay/src/main.cpp
@@ -118,6 +118,7 @@ public:
         list->addItem(new tsl::elm::CategoryHeader("NIFM - 010000000000000F"));
         list->addItem(config_ctest.create_list_item("ctest"));
         list->addItem(config_ctest2.create_list_item("ctest2"));
+        list->addItem(config_ctest3.create_list_item("ctest3"));
 
         list->addItem(new tsl::elm::CategoryHeader("NIM - 0100000000000025"));
         list->addItem(config_nim_old.create_list_item("nim_old"));
@@ -145,6 +146,7 @@ public:
     ConfigEntry config_es3{"es", "es3", true};
     ConfigEntry config_ctest{"nifm", "ctest", true};
     ConfigEntry config_ctest2{"nifm", "ctest2", true};
+    ConfigEntry config_ctest3{"nifm", "ctest3", true};
     ConfigEntry config_nim_old{"nim_old", "nim_old", true};
     ConfigEntry config_nim_new{"nim_new", "nim_new", true};
     ConfigEntry config_ssl1{"ssl", "disablecaverification1", false};

--- a/sysmod/src/main.cpp
+++ b/sysmod/src/main.cpp
@@ -194,6 +194,10 @@ constexpr auto b_cond(u32 inst) -> bool {
     return type == 0x14 || type == 0x17;
 }
 
+constexpr auto stp_cond(u32 inst) -> bool {
+    return (inst >> 24) == 0xA9; // stp x29, x30, [sp, #-0x30]!
+}
+
 // to view patches, use https://armconverter.com/?lock=arm64
 constexpr PatchData ret0_patch_data{ "0xE0031F2A" };
 constexpr PatchData ret1_patch_data{ "0x10000014" };
@@ -285,8 +289,10 @@ constinit Patterns es_patterns[] = {
 
 constinit Patterns nifm_patterns[] = {
     { "ctest", "....................F40300AA....F30314AAE00314AA9F0201397F8E04F8", 16, -16, ctest_cond, ctest_patch, ctest_applied, true, FW_VER_ANY, MAKEHOSVERSION(18,1,0) }, // 1.0.0 - 18.1.0
-    { "ctest2", "14...........91...........97...............14", 37, 4, b_cond, ctest_patch, ctest_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY }, //19.0.0 - 20.0.1+
+    { "ctest2", "14...........91...........97...............14", 41, 0, stp_cond, ctest_patch, ctest_applied, true, MAKEHOSVERSION(19,0,0), MAKEHOSVERSION(20,5,0) }, //19.0.0 - 20.5.0
+    { "ctest3", "14...........91...........97...............14", 49, 0, stp_cond, ctest_patch, ctest_applied, true, MAKEHOSVERSION(21,0,0), FW_VER_ANY }, //21.0.0
 };
+
 
 constinit Patterns nim_patterns[] = {
     { "nim_old", "0x.0F00351F2003D5", 8, 0, adr_cond, mov2_patch, mov2_applied, true, MAKEHOSVERSION(17,0,0), MAKEHOSVERSION(20,5,0) },


### PR DESCRIPTION
attempt to solve nifm checking for an unrelated branch loader arm instruction and never verifying the bytes it's intended to patch.