### PR TITLE
Correct Typos on Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ $(TARGETS):
 
 clean:
 	@rm -rf out
+	@rm -f sys-patch.zip
 	@for i in $(TARGETS); do $(MAKE) -C $$i clean || exit 1; done;
 
 dist: all

--- a/sysmod/Makefile
+++ b/sysmod/Makefile
@@ -180,14 +180,14 @@ else
 	@rm -fr $(BUILD) $(TARGET).nsp $(TARGET).nso $(TARGET).npdm $(TARGET).elf
 endif
 	@rm -rf out/
-	@rm -f sys-patch.zip
+	@rm -f sys-patch-sysmodule.zip
 
 #---------------------------------------------------------------------------------
 dist: all
 	@echo making dist ...
 
-	@rm -f sys-patch-no-overlay.zip
-	@cd out; zip -r ../sys-patch-no-overlay.zip ./*; cd ../
+	@rm -f sys-patch-sysmodule.zip
+	@cd out; zip -r ../sys-patch-sysmodule.zip ./*; cd ../
 #---------------------------------------------------------------------------------
 else
 .PHONY:	all


### PR DESCRIPTION
Correct some Typos on Makefiles which avoid the complete clean of files at `make clean`