### PR TITLE
version 1.6.0 - mostly refactor - 22.0.0 es fix

### DIFF
--- a/.github/workflows/build-jobs.yaml
+++ b/.github/workflows/build-jobs.yaml
@@ -20,24 +20,34 @@ jobs:
 
     - name: Build sys-patch
       run: |
+
+        LIBNX_VER=$(dkp-pacman -Q libnx | cut -d' ' -f2 | cut -d- -f1)
+        echo "Detected libnx version: $LIBNX_VER"
+        
         make -C sys-patch -j$(nproc) dist && \
+
         VERSION=$(grep 'export VERSION := ' sys-patch/Makefile | cut -c 19-)
         TAGVERSION=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | grep "tag_name" | head -1 | cut -d '"' -f 4)
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
         echo "TAGVERSION=${TAGVERSION}" >> $GITHUB_ENV
+        mv sys-patch/sys-patch.zip sys-patch/sys-patch-v$VERSION.zip
+        SHA256=$(sha256sum sys-patch/sys-patch-v$VERSION.zip)
+        echo "SHA256=${SHA256}" >> $GITHUB_ENV
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
         overwrite: true
-        name: sys-patch-${{ env.VERSION }}
+        name: sys-patch-v${{ env.VERSION }}
         path: sys-patch/out/
 
     - name: Fetch git cli and upload release
       env: 
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        echo "sys-patch/sys-patch-v${{ env.VERSION }}.zip"
+        echo "${{ env.SHA256 }}"
         if [ ${{ env.TAGVERSION }} = v${{ env.VERSION }} ];
         then echo "Tag version and makefile version are same, don't publish release, only artifact uploaded."
         else
@@ -47,6 +57,6 @@ jobs:
           chmod +x gh*/bin/gh && \
           cp gh*/bin/gh /bin/gh && \
           rm gh*.tar.gz && \
-          rm -rf gh*
-          gh release create v${{ env.VERSION }} sys-patch/sys-patch.zip --title "Sys-patch version ${{ env.VERSION }}" --repo github.com/$GITHUB_REPOSITORY
+          rm -rf gh* && \
+          gh release create v${{ env.VERSION }} sys-patch/sys-patch-v${{ env.VERSION }}.zip --title "Sys-patch version v${{ env.VERSION }}" --repo github.com/$GITHUB_REPOSITORY
         fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ firmware
 *.nacp
 *.ovl
 *.nca
+*.lst
 out
 ignoreme
 .vscode/settings.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "overlay/libtesla"]
 	path = overlay/libtesla
 	url = https://github.com/WerWolv/libtesla
-	branch = master

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFILES	:=	sysmod overlay
 TARGETS		:= $(foreach dir,$(MAKEFILES),$(CURDIR)/$(dir))
 
 # the below was taken from atmosphere + switch-examples makefile
-export VERSION := 1.5.9
+export VERSION := 1.6.0
 
 ifneq ($(strip $(shell git symbolic-ref --short HEAD 2>/dev/null)),)
 export GIT_BRANCH := $(shell git symbolic-ref --short HEAD)

--- a/overlay/src/main.cpp
+++ b/overlay/src/main.cpp
@@ -101,14 +101,14 @@ public:
         list->addItem(new tsl::elm::CategoryHeader("FS - 0100000000000000"));
         list->addItem(config_noacidsigchk1.create_list_item("noacidsigchk_1.0.0-9.2.0"));
         list->addItem(config_noacidsigchk2.create_list_item("noacidsigchk_1.0.0-9.2.0"));
-        list->addItem(config_noncasigchk1.create_list_item("noncasigchk_10.0.0-16.1.0"));
-        list->addItem(config_noncasigchk2.create_list_item("noncasigchk_17.0.0+"));
-        list->addItem(config_nocntchk1.create_list_item("nocntchk_10.0.0-18.1.0"));
-        list->addItem(config_nocntchk2.create_list_item("nocntchk_19.0.0-20.5.0"));
-        list->addItem(config_nocntchk3.create_list_item("nocntchk_21.0.0+"));
+        list->addItem(config_noncasigchk1.create_list_item("noncasigchk_1.0.0-3.0.2"));
+        list->addItem(config_noncasigchk2.create_list_item("noncasigchk_4.0.0-16.1.0"));
+        list->addItem(config_noncasigchk3.create_list_item("noncasigchk_17.0.0+"));
+        list->addItem(config_nocntchk1.create_list_item("nocntchk_1.0.0-18.1.0"));
+        list->addItem(config_nocntchk2.create_list_item("nocntchk_19.0.0+"));
 
         list->addItem(new tsl::elm::CategoryHeader("LDR - 0100000000000001"));
-        list->addItem(config_noacidsigchk3.create_list_item("noacidsigchk_10.0.0+"));
+        list->addItem(config_noacidsigchk4.create_list_item("noacidsigchk_10.0.0+"));
 
         list->addItem(new tsl::elm::CategoryHeader("ERPT - 010000000000002B"));
         list->addItem(config_no_erpt.create_list_item("no_erpt"));
@@ -132,8 +132,9 @@ public:
         list->addItem(config_nim1.create_list_item("blankcal0crashfix_17.0.0+"));
         list->addItem(config_nim_fw1.create_list_item("blockfirmwareupdates_1.0.0-5.1.0"));
         list->addItem(config_nim_fw2.create_list_item("blockfirmwareupdates_6.0.0-6.2.0"));
-        list->addItem(config_nim_fw3.create_list_item("blockfirmwareupdates_7.0.0-11.0.1"));
-        list->addItem(config_nim_fw4.create_list_item("blockfirmwareupdates_12.0.0+"));
+		list->addItem(config_nim_fw3.create_list_item("blockfirmwareupdates_7.0.0-10.2.0"));
+        list->addItem(config_nim_fw4.create_list_item("blockfirmwareupdates_11.0.0-11.0.1"));
+        list->addItem(config_nim_fw5.create_list_item("blockfirmwareupdates_12.0.0+"));
 
         frame->setContent(list);
         return frame;
@@ -141,12 +142,12 @@ public:
 
     ConfigEntry config_noacidsigchk1{"fs", "noacidsigchk_1.0.0-9.2.0", true};
     ConfigEntry config_noacidsigchk2{"fs", "noacidsigchk_1.0.0-9.2.0", true};
-    ConfigEntry config_noncasigchk1{"fs", "noncasigchk_10.0.0-16.1.0", true};
-    ConfigEntry config_noncasigchk2{"fs", "noncasigchk_17.0.0+", true};
-    ConfigEntry config_nocntchk1{"fs", "nocntchk_10.0.0-18.1.0", true};
-    ConfigEntry config_nocntchk2{"fs", "nocntchk_19.0.0-20.5.0", true};
-    ConfigEntry config_nocntchk3{"fs", "nocntchk_21.0.0+", true};
-    ConfigEntry config_noacidsigchk3{"ldr", "noacidsigchk_10.0.0+", true};
+    ConfigEntry config_noncasigchk1{"fs", "noncasigchk_1.0.0-3.0.2", true};
+    ConfigEntry config_noncasigchk2{"fs", "noncasigchk_4.0.0-16.1.0", true};
+    ConfigEntry config_noncasigchk3{"fs", "noncasigchk_17.0.0+", true};
+    ConfigEntry config_nocntchk1{"fs", "nocntchk_1.0.0-18.1.0", true};
+    ConfigEntry config_nocntchk2{"fs", "nocntchk_19.0.0+", true};
+    ConfigEntry config_noacidsigchk4{"ldr", "noacidsigchk_10.0.0+", true};
     ConfigEntry config_no_erpt{"erpt", "no_erpt", true};
     ConfigEntry config_es1{"es", "es_1.0.0-8.1.1", true};
     ConfigEntry config_es2{"es", "es_9.0.0-11.0.1", true};
@@ -160,8 +161,9 @@ public:
     ConfigEntry config_nim1{"nim", "blankcal0crashfix_17.0.0+", true};
     ConfigEntry config_nim_fw1{"nim", "blockfirmwareupdates_1.0.0-5.1.0", true};
     ConfigEntry config_nim_fw2{"nim", "blockfirmwareupdates_6.0.0-6.2.0", true};
-    ConfigEntry config_nim_fw3{"nim", "blockfirmwareupdates_7.0.0-11.0.1", true};
-    ConfigEntry config_nim_fw4{"nim", "blockfirmwareupdates_12.0.0+", true};
+    ConfigEntry config_nim_fw3{"nim", "blockfirmwareupdates_7.0.0-10.2.0", true};
+    ConfigEntry config_nim_fw4{"nim", "blockfirmwareupdates_11.0.0-11.0.1", true};
+    ConfigEntry config_nim_fw5{"nim", "blockfirmwareupdates_12.0.0+", true};
 };
 
 class GuiLog final : public tsl::Gui {
@@ -198,17 +200,21 @@ public:
                 #undef F
 
                 if (value.starts_with("Patched")) {
-                    if (value.ends_with("(sys-patch)")) {
-                        user->list->addItem(new tsl::elm::ListItem(Key, "Patched", colour_syspatch));
-                    } else {
-                        user->list->addItem(new tsl::elm::ListItem(Key, "Patched", colour_file));
-                    }
+                    auto *item = new tsl::elm::ListItem(Key);
+                    item->setValue("Patched", true);
+                    user->list->addItem(item);
                 } else if (value.starts_with("Unpatched") || value.starts_with("Disabled")) {
-                    user->list->addItem(new tsl::elm::ListItem(Key, Value, colour_unpatched));
+                    auto *item = new tsl::elm::ListItem(Key);
+                    item->setValue(Value, true);
+                    user->list->addItem(item);
                 } else if (user->last_section == "stats") {
-                    user->list->addItem(new tsl::elm::ListItem(Key, Value, tsl::style::color::ColorDescription));
+                    auto *item = new tsl::elm::ListItem(Key);
+                    item->setValue(Value, true);
+                    user->list->addItem(item);
                 } else {
-                    user->list->addItem(new tsl::elm::ListItem(Key, Value, tsl::style::color::ColorText));
+                    auto *item = new tsl::elm::ListItem(Key);
+                    item->setValue(Value, true);
+                    user->list->addItem(item);
                 }
 
                 return 1;

--- a/overlay/src/main.cpp
+++ b/overlay/src/main.cpp
@@ -117,7 +117,8 @@ public:
         list->addItem(config_es1.create_list_item("es_1.0.0-8.1.1"));
         list->addItem(config_es2.create_list_item("es_9.0.0-11.0.1"));
         list->addItem(config_es3.create_list_item("es_12.0.0-18.1.0"));
-        list->addItem(config_es4.create_list_item("es_19.0.0+"));
+        list->addItem(config_es4.create_list_item("es_19.0.0-21.2.0"));
+        list->addItem(config_es5.create_list_item("es_22.0.0+"));
 
         list->addItem(new tsl::elm::CategoryHeader("OLSC - 010000000000003E"));
         list->addItem(config_olsc1.create_list_item("olsc_6.0.0-14.1.2"));
@@ -152,7 +153,8 @@ public:
     ConfigEntry config_es1{"es", "es_1.0.0-8.1.1", true};
     ConfigEntry config_es2{"es", "es_9.0.0-11.0.1", true};
     ConfigEntry config_es3{"es", "es_12.0.0-18.1.0", true};
-    ConfigEntry config_es4{"es", "es_19.0.0+", true};
+    ConfigEntry config_es4{"es", "es_19.0.0-21.2.0", true};
+    ConfigEntry config_es5{"es", "es_22.0.0+", true};
     ConfigEntry config_olsc1{"olsc", "olsc_6.0.0-14.1.2", true};
     ConfigEntry config_olsc2{"olsc", "olsc_15.0.0-18.1.0", true};
     ConfigEntry config_olsc3{"olsc", "olsc_19.0.0+", true};

--- a/sysmod/Makefile
+++ b/sysmod/Makefile
@@ -56,6 +56,7 @@ CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
 CXXFLAGS	:= $(CFLAGS) -std=c++23 -fno-rtti -fno-exceptions
+CXXFLAGS += $(EXTRA_FLAGS)
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/sysmod/src/main.cpp
+++ b/sysmod/src/main.cpp
@@ -20,17 +20,6 @@ u8 AMS_KEYGEN{}; // set on startup
 u64 AMS_HASH{}; // set on startup
 bool VERSION_SKIP{}; // set on startup
 
-struct DebugEventInfo {
-    u32 event_type;
-    u32 flags;
-    u64 thread_id;
-    u64 title_id;
-    u64 process_id;
-    char process_name[12];
-    u32 mmu_flags;
-    u8 _0x30[0x10];
-};
-
 template<typename T>
 constexpr void str2hex(const char* s, T* data, u8& size) {
     // skip leading 0x (if any)
@@ -49,7 +38,7 @@ constexpr void str2hex(const char* s, T* data, u8& size) {
     while (*s != '\0') {
         if (sizeof(T) == sizeof(u16) && *s == '.') {
             data[size] = REGEX_SKIP;
-            s++;
+            s += 2; // consume both dots of ".."
         } else {
             data[size] |= hexstr_2_nibble(*s++) << 4;
             data[size] |= hexstr_2_nibble(*s++) << 0;
@@ -235,14 +224,33 @@ constexpr auto ctest_applied(const u8* data, u32 inst) -> bool {
     return ctest_patch(inst).cmp(data);
 }
 
+// patterns should be optimized in such a manner that they yield only one result.
+// patterns might yield results for more firmware versions, but if it yields more than one result (per firmware version), it should be condensed to near similar versions instead which only yields one result.
+// a pattern should not contain the bytes being patched, they should be wildcarded.
+// if the bytes being patched align with the patch partially, then the partial bytes can be in the pattern, the same applies to if the pattern contains the length of the patch.
+// the bytes being tested are defined by the _cond, and does not need to be in the pattern, and shouldn't be in the pattern, if the bytes being tested are also the bytes being patched.
+// () indicate testing, {} indicate what is being patched
+// example:
+// "0x00....0240F9........E8", 6, 0,
+// the bytes being tested, and patch size is the same, 6 from start of pattern, then patch 0 from start of where the test was designated:
+// "0x00....0240F9{(........)}E8"
+// if moving the head from what is being tested, the bytes, if in pattern, should be wildcarded by the length of the patch being applied
+// "0x00....0240F9........E8C8FE4739", 6, 4,
+// example {} should be wildcarded, as those are the bytes being patched, the bytes being tested can in that context contain bytes in the pattern:
+// "0x00....0240F9(......94){E8C8FE47}39", 6, 4,
+// example with wildcarding:
+// "0x00....0240F9(......94){........}39", 6, 4,
+//
+// designing new patterns should ideally conform to specification above.
+
 constinit Patterns fs_patterns[] = {
     { "noacidsigchk_1.0.0-9.2.0", "0xC8FE4739", -24, 0, bl_cond, ret0_patch, ret0_applied, true, FW_VER_ANY, MAKEHOSVERSION(9,2,0) }, // moved to loader 10.0.0
     { "noacidsigchk_1.0.0-9.2.0", "0x0210911F000072", -5, 0, bl_cond, ret0_patch, ret0_applied, true, FW_VER_ANY, MAKEHOSVERSION(9,2,0) }, // moved to loader 10.0.0
-    { "noncasigchk_10.0.0-16.1.0", "0x1E48391F.0071..0054", -17, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(10,0,0), MAKEHOSVERSION(16,1,0) },
-    { "noncasigchk_17.0.0+", "0x0694..00.42.0091", -18, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(17,0,0), FW_VER_ANY },
-    { "nocntchk_10.0.0-18.1.0", "0x00..0240F9....08.....00...00...0037", 6, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(10,0,0), MAKEHOSVERSION(18,1,0) },
-    { "nocntchk_19.0.0-20.5.0", "0x00..0240F9....08.....00...00...0054", 6, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(19,0,0), MAKEHOSVERSION(20,5,0) },
-    { "nocntchk_21.0.0+", "0x00..0240F9....E8.....00...00...0054", 6, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(21,0,0), FW_VER_ANY },
+    { "noncasigchk_1.0.0-3.0.2", "0x88..42..58", -4, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(3,0,2) },
+    { "noncasigchk_4.0.0-16.1.0", "0x1E4839....00......0054", -17, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(4,0,0), MAKEHOSVERSION(16,1,0) },
+    { "noncasigchk_17.0.0+", "0x0694....00..42..0091", -18, 0, tbz_cond, nop_patch, nop_applied, true, MAKEHOSVERSION(17,0,0), FW_VER_ANY },
+    { "nocntchk_1.0.0-18.1.0", "0x40F9........081C00121F05", 2, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(18,1,0) },
+    { "nocntchk_19.0.0+", "0x40F9............40B9091C", 2, 0, bl_cond, ret0_patch, ret0_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
 };
 
 constinit Patterns ldr_patterns[] = {
@@ -250,33 +258,34 @@ constinit Patterns ldr_patterns[] = {
 };
 
 constinit Patterns erpt_patterns[] = {
-    { "no_erpt", "0x...D1FD7B02A9FD830091F76305A9", 0, 0, sub_cond, mov0_ret_patch, mov0_ret_applied, true, FW_VER_ANY }, // FF4305D1 - sub sp, sp, #0x150 patched to E0031F2AC0035FD6 - mov w0, wzr, ret 
+    { "no_erpt", "0xFD7B02A9FD830091F76305A9", -4, 0, sub_cond, mov0_ret_patch, mov0_ret_applied, true, FW_VER_ANY }, // FF4305D1 - sub sp, sp, #0x150 patched to E0031F2AC0035FD6 - mov w0, wzr, ret 
 };
 
 constinit Patterns es_patterns[] = {
-    { "es_1.0.0-8.1.1", "0x....E8.00...FF97.0300AA..00.....E0.0091..0094.7E4092.......A9", 36, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(8,1,1) },
-    { "es_9.0.0-11.0.1", "0x00...............00.....A0..D1...97.......A9", 30, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(9,0,0), MAKEHOSVERSION(11,0,1) },
-    { "es_12.0.0-18.1.0", "0x02.00...........00...00.....A0..D1...97.......A9", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(12,0,0), MAKEHOSVERSION(18,1,0) },
-    { "es_19.0.0+", "0xA1.00...........00...00.....A0..D1...97.......A9", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
+    { "es_1.0.0-8.1.1", "0x0091....0094..7E4092", 10, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(8,1,1) },
+    { "es_9.0.0-11.0.1", "0x00..........A0....D1....FF97", 14, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(9,0,0), MAKEHOSVERSION(11,0,1) },
+    { "es_12.0.0-18.1.0", "0x02........D2..52....0091", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(12,0,0), MAKEHOSVERSION(18,1,0) },
+    { "es_19.0.0+", "0xA1........031F2A....0091", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
 };
 
 constinit Patterns olsc_patterns[] = {
-    { "olsc_6.0.0-14.1.2", "0x00.73..F968024039..00...00", 42, 0, bl_cond, ret1_patch, ret1_applied, true, MAKEHOSVERSION(6,0,0), MAKEHOSVERSION(14,1,2) },
-    { "olsc_15.0.0-18.1.0", "0x00.73..F968024039..00...00", 38, 0, bl_cond, ret1_patch, ret1_applied, true, MAKEHOSVERSION(15,0,0), MAKEHOSVERSION(18,1,0) },
-    { "olsc_19.0.0+", "0x00.73..F968024039..00...00", 42, 0, bl_cond, ret1_patch, ret1_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
+    { "olsc_6.0.0-14.1.2", "0x00..73....F9....4039", 42, 0, bl_cond, ret1_patch, ret1_applied, true, MAKEHOSVERSION(6,0,0), MAKEHOSVERSION(14,1,2) },
+    { "olsc_15.0.0-18.1.0", "0x00..73....F9....4039", 38, 0, bl_cond, ret1_patch, ret1_applied, true, MAKEHOSVERSION(15,0,0), MAKEHOSVERSION(18,1,0) },
+    { "olsc_19.0.0+", "0x00..73....F9....4039", 42, 0, bl_cond, ret1_patch, ret1_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
 };
 
 constinit Patterns nifm_patterns[] = {
-    { "ctest_1.0.0-19.0.1", "0x03.AAE003.AA...39..04F8....E0", -29, 0, ctest_cond, ctest_patch, ctest_applied, true, FW_VER_ANY, MAKEHOSVERSION(18,1,0) },
-    { "ctest_20.0.0+", "0x03.AA...AA.........0314AA..14AA", -17, 0, ctest_cond, ctest_patch, ctest_applied, true, MAKEHOSVERSION(20,0,0), FW_VER_ANY },
+    { "ctest_1.0.0-19.0.1", "0x03..AAE003..AA......39....04F8........E0", -29, 0, ctest_cond, ctest_patch, ctest_applied, true, FW_VER_ANY, MAKEHOSVERSION(19,0,1) },
+    { "ctest_20.0.0+", "0x03..AA......AA..................0314AA....14AA", -17, 0, ctest_cond, ctest_patch, ctest_applied, true, MAKEHOSVERSION(20,0,0), FW_VER_ANY },
 };
 
 constinit Patterns nim_patterns[] = {
-    { "blankcal0crashfix_17.0.0+", "0x00351F2003D5...............97..0094..00.....61", 6, 0, adr_cond, mov2_patch, mov2_applied, true, MAKEHOSVERSION(17,0,0), FW_VER_ANY },
-    { "blockfirmwareupdates_1.0.0-5.1.0", "0x1139F30301AA81.40F9E0.1191", -30, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(5,1,0) },
-    { "blockfirmwareupdates_6.0.0-6.2.0", "0xF30301AA.4E40F9E0..91", -40, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(6,0,0), MAKEHOSVERSION(6,2,0) },
-    { "blockfirmwareupdates_7.0.0-11.0.1", "0xF30301AA014C40F9F40300AAE0..91", -36, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(7,0,0), MAKEHOSVERSION(11,0,1) },
-    { "blockfirmwareupdates_12.0.0+", "0x280841F9084C00F9E0031F.C0035FD6", 16, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(12,0,0), FW_VER_ANY },
+    { "blankcal0crashfix_17.0.0+", "0x00351F2003D5..............................97....0094....00..........61", 6, 0, adr_cond, mov2_patch, mov2_applied, true, MAKEHOSVERSION(17,0,0), FW_VER_ANY },
+    { "blockfirmwareupdates_1.0.0-5.1.0", "0x1139F3", -30, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(5,1,0) },
+    { "blockfirmwareupdates_6.0.0-6.2.0", "0xF30301AA..4E", -40, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(6,0,0), MAKEHOSVERSION(6,2,0) },
+    { "blockfirmwareupdates_7.0.0-10.2.0", "0xF30301AA014C", -36, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(7,0,0), MAKEHOSVERSION(10,2,0) },
+    { "blockfirmwareupdates_11.0.0-11.0.1", "0x9AF0....................C0035FD6", 16, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(11,0,0), MAKEHOSVERSION(11,0,1) },
+    { "blockfirmwareupdates_12.0.0+", "0x41....4C............C0035FD6", 14, 0, block_fw_updates_cond, mov0_ret_patch, mov0_ret_applied, true, MAKEHOSVERSION(12,0,0), FW_VER_ANY },
 };
 
 // NOTE: add system titles that you want to be patched to this table.
@@ -409,7 +418,7 @@ auto apply_patch(PatchEntry& patch) -> bool {
     for (s32 i = 0; i < (process_count - 1); i++) {
         if (R_SUCCEEDED(svcDebugActiveProcess(&handle, pids[i])) &&
             R_SUCCEEDED(svcGetDebugEvent(&event_info, handle)) &&
-            patch.title_id == event_info.title_id) {
+            patch.title_id == event_info.info.create_process.program_id) {
             MemoryInfo mem_info{};
             u64 addr{};
             u32 page_info{};

--- a/sysmod/src/main.cpp
+++ b/sysmod/src/main.cpp
@@ -265,7 +265,8 @@ constinit Patterns es_patterns[] = {
     { "es_1.0.0-8.1.1", "0x0091....0094..7E4092", 10, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(1,0,0), MAKEHOSVERSION(8,1,1) },
     { "es_9.0.0-11.0.1", "0x00..........A0....D1....FF97", 14, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(9,0,0), MAKEHOSVERSION(11,0,1) },
     { "es_12.0.0-18.1.0", "0x02........D2..52....0091", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(12,0,0), MAKEHOSVERSION(18,1,0) },
-    { "es_19.0.0+", "0xA1........031F2A....0091", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(19,0,0), FW_VER_ANY },
+    { "es_19.0.0-21.2.0", "0xA1........031F2A....0091", 32, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(19,0,0), MAKEHOSVERSION(21,2,0) },
+    { "es_22.0.0+", "0xA0630091....FE97A08300D1....FE97", 16, 0, es_cond, mov0_patch, mov0_applied, true, MAKEHOSVERSION(22,0,0), FW_VER_ANY },
 };
 
 constinit Patterns olsc_patterns[] = {


### PR DESCRIPTION
updates the overlay a tiny bit, and all patterns, and adds wildcard nibble support.

version 1.6.0 contains some refactoring and compatability with latest set of libnx commits (not in latest libnx release yet)
(these two specifically)
https://github.com/switchbrew/libnx/pull/702
https://github.com/switchbrew/libnx/pull/707

and a temproary build flag to accomodate libnx in devkita64 not being updated to latest, and still compile, if needed.